### PR TITLE
chore(gitignore): narrow env ignore patterns to preserve non-prod env…

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -27,4 +27,4 @@ dist-ssr
 .netlify
 combined_project_files.txt
 mob-dev-plan.md
-.env*
+.env.production

--- a/cabindia-backend/.env.example
+++ b/cabindia-backend/.env.example
@@ -1,0 +1,86 @@
+# ============================================
+# CABINDIA BACKEND ENVIRONMENT VARIABLES
+# ============================================
+
+# --------------------------------------------
+# DATABASE CONFIGURATION
+# --------------------------------------------
+# MySQL Database Configuration
+DB_HOST=your-database-host
+DB_USER=your-database-username
+DB_PASSWORD=your-database-password
+DB_NAME=your-database-name
+DB_PORT=3306
+
+# For Aiven MySQL with SSL (recommended)
+# DB_HOST=your-aiven-host.aivencloud.com
+# DB_USER=avnadmin
+# DB_PASSWORD=your-strong-password
+# DB_NAME=defaultdb
+# DB_PORT=12291
+
+# --------------------------------------------
+# EMAIL SERVICE (for contact form)
+# --------------------------------------------
+# Option 1: Gmail with App Password
+# Generate app password: https://myaccount.google.com/apppasswords
+EMAIL_USER=your-email@gmail.com
+EMAIL_PASS=your-gmail-app-password-16-char
+CONTACT_SERVICE_EMAIL=support@cabindia.com
+
+# Option 2: SendGrid / SMTP
+# EMAIL_HOST=smtp.sendgrid.net
+# EMAIL_PORT=587
+# EMAIL_USER=apikey
+# EMAIL_PASS=your-sendgrid-api-key
+
+# Option 3: Mailgun
+# EMAIL_HOST=smtp.mailgun.org
+# EMAIL_PORT=587
+# EMAIL_USER=postmaster@your-domain.com
+# EMAIL_PASS=your-mailgun-smtp-password
+
+# --------------------------------------------
+# JWT AUTHENTICATION
+# --------------------------------------------
+# Generate a strong secret using:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+#   OR
+#   openssl rand -base64 32
+JWT_SECRET=your-strong-jwt-secret-key
+JWT_EXPIRES_IN=7d
+
+# --------------------------------------------
+# GOOGLE MAPS API (for backend geocoding)
+# --------------------------------------------
+GOOGLE_MAPS_API_KEY=your-google-maps-api-key
+
+# --------------------------------------------
+# SERVER CONFIGURATION
+# --------------------------------------------
+PORT=5000
+NODE_ENV=development
+
+# For production:
+# NODE_ENV=production
+
+# --------------------------------------------
+# CORS CONFIGURATION
+# --------------------------------------------
+# For development (allow all):
+CORS_ORIGIN=*
+
+# For production (specific origins):
+# CORS_ORIGIN=https://cabindia-mobile.onrender.com,https://your-frontend-domain.com
+
+# --------------------------------------------
+# SECURITY OPTIONS
+# --------------------------------------------
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_MAX_REQUESTS=100
+BCRYPT_ROUNDS=12
+
+# --------------------------------------------
+# LOGGING
+# --------------------------------------------
+LOG_LEVEL=info

--- a/cabindia-backend/.env.production.example
+++ b/cabindia-backend/.env.production.example
@@ -1,0 +1,56 @@
+# ============================================
+# CABINDIA PRODUCTION ENVIRONMENT
+# ============================================
+
+# --------------------------------------------
+# DATABASE (Production - Aiven / AWS RDS / etc.)
+# --------------------------------------------
+DB_HOST=your-production-db-host
+DB_USER=your-production-db-user
+DB_PASSWORD=your-production-db-password
+DB_NAME=your-production-db-name
+DB_PORT=12291
+
+# For SSL connections (add if required):
+# DB_SSL=true
+
+# --------------------------------------------
+# EMAIL (Production)
+# --------------------------------------------
+EMAIL_USER=contact@cabindia.com
+EMAIL_PASS=your-production-email-password
+CONTACT_SERVICE_EMAIL=team@cabindia.com
+
+# --------------------------------------------
+# JWT - STRONG RANDOM SECRET
+# --------------------------------------------
+JWT_SECRET=your-production-jwt-secret
+JWT_EXPIRES_IN=7d
+
+# --------------------------------------------
+# GOOGLE MAPS (Production API Key)
+# --------------------------------------------
+GOOGLE_MAPS_API_KEY=YOUR_ACTUAL_GOOGLE_MAPS_API_KEY
+
+# --------------------------------------------
+# SERVER
+# --------------------------------------------
+PORT=5000
+NODE_ENV=production
+
+# --------------------------------------------
+# CORS - Allow multiple origins
+# --------------------------------------------
+CORS_ORIGIN=https://cabindia-mobile.onrender.com,https://cabindia-web.onrender.com
+
+# --------------------------------------------
+# SECURITY
+# --------------------------------------------
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_MAX_REQUESTS=100
+BCRYPT_ROUNDS=12
+
+# --------------------------------------------
+# LOGGING
+# --------------------------------------------
+LOG_LEVEL=error

--- a/cabindia-mobile/.env.example
+++ b/cabindia-mobile/.env.example
@@ -1,0 +1,61 @@
+# ============================================
+# CABINDIA MOBILE APP ENVIRONMENT VARIABLES
+# ============================================
+
+# --------------------------------------------
+# API CONFIGURATION
+# --------------------------------------------
+# Your backend URL (local development vs production)
+# For local development:
+# API_URL=http://localhost:5000
+API_URL=https://your-backend-url.onrender.com
+
+# --------------------------------------------
+# SOCKET.IO CONFIGURATION
+# --------------------------------------------
+# For real-time ride tracking
+SOCKET_URL=https://your-backend-url.onrender.com
+
+# For local development:
+# SOCKET_URL=http://localhost:5000
+
+# --------------------------------------------
+# GOOGLE MAPS CONFIGURATION
+# --------------------------------------------
+# Get your keys from Google Cloud Console
+GOOGLE_MAPS_API_KEY_ANDROID=YOUR_ANDROID_GOOGLE_MAPS_API_KEY
+GOOGLE_MAPS_API_KEY_IOS=YOUR_IOS_GOOGLE_MAPS_API_KEY
+GOOGLE_MAPS_API_KEY_WEB=YOUR_WEB_GOOGLE_MAPS_API_KEY
+
+# --------------------------------------------
+# APP CONFIGURATION
+# --------------------------------------------
+APP_NAME=CabIndia
+APP_VERSION=1.0.0
+APP_ENV=development
+
+# For production:
+# APP_ENV=production
+
+# --------------------------------------------
+# FEATURE FLAGS
+# --------------------------------------------
+# Enable or disable features
+ENABLE_GOOGLE_LOGIN=true
+ENABLE_FACEBOOK_LOGIN=false
+ENABLE_REFERRAL_PROGRAM=true
+ENABLE_CAPTCHA_ON_REGISTER=false
+
+# --------------------------------------------
+# ANALYTICS
+# --------------------------------------------
+# Google Analytics / Firebase Analytics IDs
+# FIREBASE_ANALYTICS_COLLECTION_ENABLED=true
+# GOOGLE_ANALYTICS_ID=UA-XXXXXXXXX-X
+
+# --------------------------------------------
+# NOTIFICATIONS
+# --------------------------------------------
+# Firebase Cloud Messaging (FCM) configuration
+# FCM_SENDER_ID=your-fcm-sender-id
+# FCM_SERVER_KEY=your-fcm-server-key

--- a/cabindia-mobile/.gitignore
+++ b/cabindia-mobile/.gitignore
@@ -39,4 +39,4 @@ yarn-error.*
 # generated native folders
 /ios
 /android
-.env*
+.env


### PR DESCRIPTION
… files

Previous .env* ignore rule in both .gitignore files was overly broad, excluding all .env-prefixed files including development, staging, and other environment configs that should not be ignored. Updated root .gitignore to only ignore .env.production, and cabindia-mobile/.gitignore to only ignore .env to preserve access to non-production environment files.