### PR TITLE
refactor(backend): improve database test script output and port config

### DIFF
--- a/cabindia-backend/test-db.js
+++ b/cabindia-backend/test-db.js
@@ -1,13 +1,11 @@
-// cabindia-backend/test-db.js
 const mysql = require('mysql2/promise');
 require('dotenv').config();
 
 async function testConnection() {
-  console.log('Testing database connection...');
+  console.log('🔍 Testing database connection...');
   console.log('Host:', process.env.DB_HOST);
   console.log('User:', process.env.DB_USER);
   console.log('Database:', process.env.DB_NAME);
-  console.log('Port:', process.env.DB_PORT);
   
   try {
     const connection = await mysql.createConnection({
@@ -15,23 +13,26 @@ async function testConnection() {
       user: process.env.DB_USER,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
-      port: parseInt(process.env.DB_PORT) || 12291,
-      ssl: {
-        rejectUnauthorized: false,
-      },
+      port: parseInt(process.env.DB_PORT) || 3306,
       connectTimeout: 30000,
     });
     
     console.log('✅ Connection successful!');
     
-    const [result] = await connection.execute('SELECT 1 as test, NOW() as time');
-    console.log('Query result:', result);
+    // Test queries
+    const [users] = await connection.execute('SELECT COUNT(*) as count FROM users');
+    console.log(`👤 Users: ${users[0].count}`);
+    
+    const [drivers] = await connection.execute('SELECT COUNT(*) as count FROM drivers');
+    console.log(`🚗 Drivers: ${drivers[0].count}`);
+    
+    const [rides] = await connection.execute('SELECT COUNT(*) as count FROM rides');
+    console.log(`🚕 Rides: ${rides[0].count}`);
     
     await connection.end();
-    console.log('✅ Test completed successfully!');
+    console.log('✅ All tests passed! Database is ready.');
   } catch (error) {
     console.error('❌ Connection failed:', error.message);
-    console.error('Error details:', error);
   }
 }
 


### PR DESCRIPTION
Updated database test script to use standard MySQL default port (3306), removed redundant SSL config and port logging. Replaced generic test query with per-table count checks for users, drivers, and rides to verify data access, added emoji indicators for clearer log output, and simplified error messaging. Removed unnecessary file header comment for cleaner code, making the test utility more practical for verifying database connectivity with actionable results.